### PR TITLE
DNM: suggest fix for main.qml:69:14 error flood in jounralctl

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -81,7 +81,7 @@ Item {
 				PlasmaComponents.BusyIndicator {
 					width: parent.height
 					height: parent.height
-					anchors.horizontalCenter: icon.horizontalCenter
+					//anchors.horizontalCenter: icon.horizontalCenter
 					running: model.refreshing
 					visible: model.refreshing
 				}
@@ -99,8 +99,8 @@ Item {
 				PlasmaComponents.Label {
 					id: nameText
 					
-					anchors.left: icon.right
-					anchors.leftMargin: 10
+					//anchors.left: icon.right
+					//anchors.leftMargin: 10
 					
 					height: parent.height
 					text: model.name.length == 0 ? model.hostname : model.name
@@ -111,10 +111,10 @@ Item {
 				MouseArea {
 					id: mouseArea
 					
-					anchors.top: icon.top
-					anchors.right: nameText.right
-					anchors.bottom: icon.bottom
-					anchors.left: icon.left
+					//anchors.top: icon.top
+					//anchors.right: nameText.right
+					//anchors.bottom: icon.bottom
+					//anchors.left: icon.left
 					hoverEnabled: true
 					onClicked: {
 						refreshServer(model.index)


### PR DESCRIPTION
The error message below displayed every refresh in journalctl on Fedora 31
```
Nov 25 11:12:57 plasmashell[2563355]: file:///home/user/.local/share/plasma/plasmoids/org.kde.plasma.serverstatus/contents/ui/main.qml:69:14:
QML Row: Cannot specify left, right, horizontalCenter, fill or center In anchors for items inside Row. Row will not function.
```